### PR TITLE
Fix: フォームデータ送信に対するエラー解消

### DIFF
--- a/src/clnd/app/Http/Controllers/RegisterController.php
+++ b/src/clnd/app/Http/Controllers/RegisterController.php
@@ -13,14 +13,14 @@ class RegisterController extends Controller {
       'email' => 'required| string | email | unique:users',
       'password' => 'required | string | min: 8',
     ]);
-    dd($formData);
+    //dd($formData);
 
     $user = User::create([
       'name' => $request->input('name'),
       'email' => $request->input('email'),
       'password' => Hash::make($request->input('password')),
     ]);
-    dd($user);
+    //dd($user);
     return response()->json(['message' => 'ユーザー登録が完了しました', 'user' => $user]);
   }
 }

--- a/src/clnd/resources/js/Pages/Register.jsx
+++ b/src/clnd/resources/js/Pages/Register.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import Common from '../Layout/common';
 import Register from '../css/register.module.css';
-import axios from 'axios';
+//import axios from 'axios';
 
 function RegistrationForm() {
   const [formData, setFormData] = useState({
@@ -22,48 +22,52 @@ function RegistrationForm() {
     event.preventDefault();
 
     // laravelのエンドポイント
-    const apiUrl = 'http://localhost/api/register';
-    console.log(apiUrl);
+    const apiUrl = '/api/register';
 
-    const data = { // 送信データを定義
-      name: formData.name,
-      email: formData.email,
-      password: formData.password,
-    };
+    // const data = { // 送信データを定義
+    //   name: formData.name,
+    //   email: formData.email,
+    //   password: formData.password,
+    // };
 
-    axios.post(apiUrl, data, {
+    // axios.get('/') 
+    //   .then(response => {
+    //     console.log(response);
+    //   })
+    
+    // axios.post(apiUrl, data, {
+    //   headers: {
+    //     'Content-Type': 'application/json',
+    //     'X-CSRF-TOKEN': window.csrfToken,
+    //   },
+    // })
+    // .then(response => {
+    //   console.log('送信完了', response.data);
+    // })
+    // .catch(error => {
+    //   console.log('エラー', error);
+    // });
+
+    // 送信形態
+    const requestOptions = {
+      method: 'POST',
       headers: {
         'Content-Type': 'application/json',
         'X-CSRF-TOKEN': window.csrfToken,
       },
-    })
-    .then(response => {
-      console.log('送信完了', response.data);
-    })
-    .catch(error => {
-      console.log('エラー', error);
-    });
-    //const requestOptions = {
-      //method: 'POST',
-      //headers: {
-        //'Content-Type': 'application/json',
-        //'X-CSRF-TOKEN': window.csrfToken,
-      //},
-      //body: JSON.stringify(formData),
-    //};
-    //console.log(requestOptions);
+      body: JSON.stringify(formData),
+    };
+    console.log(requestOptions);
 
     // Postリクエストを送信
-    //fetch(apiUrl,requestOptions)
-      //.then(function(response) {
-        //return response.json();
-      //})
-      //.then(data => {
-        //console.log('送信完了', data);
-      //})
-      //.catch(error => {
-        //console.log('エラー', error);
-      //});
+    fetch(apiUrl,requestOptions)
+      .then(response => response.json())
+      .then(data => {
+        console.log('送信完了', data);
+      })
+      .catch(error => {
+        console.log('エラー', error);
+      });
   }
 
   return (

--- a/src/clnd/routes/api.php
+++ b/src/clnd/routes/api.php
@@ -20,6 +20,5 @@ Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
 });
 
 // react側からフォーム送信で使用するエンドポイント
-Route::middleware('auth:api')->group(function () {
-  Route::post('/api/register', [RegisterController::class, 'register']);
-});
+Route::post('/register', [RegisterController::class, 'register']);
+


### PR DESCRIPTION
### Why

react->laravelにフォームデータを送信する際に、「エンドポイントが見つからない」と４０４エラーが出ている。

### What

api.php、Register.jsxに記述したエンドポイントの記述を変更。
送信をaxiosの使用ではなく、fetchに変更。

![スクリーンショット 2023-10-29 15 33 07](https://github.com/yuuki-kurose/clnd-main/assets/103484621/98f9f273-bf49-4178-be17-583f47457cd2)

close #7 