### PR TITLE
Add: ログイン時のエラーハンドリング設定

### DIFF
--- a/src/clnd/app/Http/Controllers/LoginController.php
+++ b/src/clnd/app/Http/Controllers/LoginController.php
@@ -7,22 +7,32 @@ use Illuminate\Support\Facades\Auth;
 
 class LoginController extends Controller {
   public function authenticate(Request $request) {
-    $loginForm = $request->validate([
-      'email' => ['required', 'email'],
-      'password' => ['required'],
-    ]);
 
-    if(Auth::attempt($loginForm)) {
-      // $request->session()->regenerate();
+    $email = $request->input('email');
+    $password = $request->input('password');
+
+    if(Auth::attempt(['email' => $email, 'password' => $password])) {
       return response()->json([
         'message' => '認証成功',
         'redirectTo' => '/calender',
       ], 200);
+    } else if(!Auth::attempt(['email' => $email])) {
+      $errors = ['email' => 'メールアドレスが間違っています'];
+      return response()->json([
+        'message' => '認証失敗',
+        'redirectTo' => '/login',
+        'errors' => $errors,
+      ], 422);
+    } else {
+      /**
+       * task: パスワードのエラーハンドリング見直し
+       */
+      $errors = ['password' => 'パスワードが間違っています'];
+      return response()->json([
+        'message' => '認証失敗',
+        'redirectTo' => '/login',
+        'errors' => $errors,
+      ], 422);
     }
-    // return back('/login')->withErrors([
-    //   'email' => 'メールアドレスが間違っています',
-    //   'password' => 'パスワードが間違っています'
-    // ]);
-    return response()->json(['message' => '認証失敗'], 401);
   }
 }

--- a/src/clnd/resources/js/Pages/Login.jsx
+++ b/src/clnd/resources/js/Pages/Login.jsx
@@ -3,14 +3,18 @@ import Common from '../Layout/common';
 import Login from '../css/login.module.css';
 
 function loginUserForm() {
+  // ログインフォーム変数定義
   const [loginForm, setLoginForm] = useState({
     name: '',
     email: '',
     password: '',
   });
 
-  // csrfトークン取得
-  // const csrfToken = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
+  // エラー変数定義
+  const [errors, setErrors] = useState({
+    email: '',
+    password: '',
+  });
 
   // 入力内容の反映
   const handleChange = (event) => {
@@ -31,21 +35,32 @@ function loginUserForm() {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        // 'X-CSRF-TOKEN': csrfToken,
       },
       body: JSON.stringify(loginForm)
     }
-    console.log(requestOptions);
 
     // laravelからレスポンスデータ取得
     fetch(apiUrl, requestOptions)
       .then(response => response.json())
       .then(data => {
-        if(data.message === '認証成功') {
+        if(data.message === "認証成功") {
           console.log(data.message);
           window.location.href = data.redirectTo;
-        } else {
-          console.log('error', data.message);
+        } else if(data.message === "認証失敗") {
+          if(data.errors.email) {
+            setErrors({
+              email: data.errors.email,
+              password: '',
+            });
+          } else if(data.errors.password) {
+            /**
+             * task: パスワードのエラーハンドリング見直し
+             */
+            setErrors({
+              email: '',
+              password: data.errors.password,
+            });
+          }
         }
       });
   }
@@ -59,11 +74,21 @@ function loginUserForm() {
         <form className={ Login.login__form } onSubmit={ handleSubmit }>
           <label>
             メールアドレス:
-            <input type="email" name="email" value={ loginForm.email } onChange={ handleChange } />
+            <input  type="email"
+                    name="email"
+                    value={ loginForm.email }
+                    onChange={ handleChange }
+            />
+            { errors.email && <div className={ Login.login__error }>{ errors.email }</div> }
           </label>
           <label>
             パスワード:
-            <input type="password" name="password" value={ loginForm.password } onChange={ handleChange } />
+            <input  type="password"
+                    name="password"
+                    value={ loginForm.password }
+                    onChange={ handleChange }
+            />
+            { errors.password && <div className={ Login.login__error }>{ errors.password }</div> }
           </label>
           <div>
             <input type="submit" value="ログイン" />

--- a/src/clnd/resources/js/css/login.module.css
+++ b/src/clnd/resources/js/css/login.module.css
@@ -10,3 +10,6 @@
   flex-direction: column;
   text-align: center;
 }
+.login__error {
+  color: red;
+}

--- a/src/clnd/routes/api.php
+++ b/src/clnd/routes/api.php
@@ -23,10 +23,9 @@ Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
 });
 
 // react側からフォーム送信で使用するエンドポイント
-Route::middleware('cors')->group(function() {
-  Route::post('/register', [RegisterController::class, 'register']);
-  Route::post('/login', [LoginController::class, 'authenticate']);
-});
+Route::post('/register', [RegisterController::class, 'register']);
+Route::post('/login', [LoginController::class, 'authenticate']);
+
 
 Route::post('/AdminRegister', [AdminRegisterController::class, 'adminRegister']);
 Route::post('/AdminLogin', [AdminLoginController::class, 'authenticate']);

--- a/src/clnd/routes/web.php
+++ b/src/clnd/routes/web.php
@@ -8,6 +8,9 @@ use Illuminate\Support\Facades\Route;
 Route::inertia('/', 'Home');
 Route::inertia('/register', 'Register');
 Route::inertia('/login', 'Login');
+/**
+ * task: 認証成功した後のルートを作成する
+ */
 Route::inertia('/calender', 'Calender');
 
 /**


### PR DESCRIPTION
### Why

ログインの際に、メールアドレス・パスワードが間違っている時のエラーメッセージを表示させる。

### What

フロント・バックエンド側にエラーの処理を追記、フロントエンドでエラーメッセージを表示させる。

![スクリーンショット 2023-11-06 20 38 41](https://github.com/yuuki-kurose/clnd-main/assets/103484621/c4db0a22-9eeb-42b0-8d26-53a25e563e27)

close #18 