### PR TITLE
Add: カレンダーページに予約登録フォームを表示させる

### DIFF
--- a/src/clnd/resources/js/Pages/Calender.jsx
+++ b/src/clnd/resources/js/Pages/Calender.jsx
@@ -1,11 +1,15 @@
 import React, { useState }  from 'react';
 import Common from '../Layout/common';
 import Calender from '../css/calender.module.css';
+import ScheduleForm from '../Pages/Schedule';
 
 function calenderUserPage() {
   // 現在の年月を取得
   const [year, setYear] = useState(new Date().getFullYear());
   const [month, setMonth] = useState(new Date().getMonth()+1);
+
+  // 予定作成フォームの状態を取得
+  const [openForm, setOpenForm] = useState(false);
 
   // カレンダーに反映する関数
   const calender = createCalender(year, month);
@@ -17,6 +21,10 @@ function calenderUserPage() {
   const prevlast = new Date(year,month-1, 0).getDate();
   console.log(prevlast);
 
+  // 予定作成フォームの表示/非表示
+  const handleClick = () => {
+    setOpenForm(!openForm);
+  };
 
   return(
     <Common>
@@ -55,6 +63,15 @@ function calenderUserPage() {
               ))}
             </tbody>
           </table>
+
+          {/* 予定作成フォームコンポーネントの呼び出し */}
+          <div>
+            <button className={ Calender.calender__btn }
+                    onClick={ handleClick }
+            >+
+            </button>
+            { openForm && <ScheduleForm />}
+          </div>
         </div>
       </div>
     </Common>

--- a/src/clnd/resources/js/Pages/Schedule.jsx
+++ b/src/clnd/resources/js/Pages/Schedule.jsx
@@ -1,5 +1,4 @@
 import { useState } from "react";
-import Common from "../Layout/common";
 import Schedule from "../css/schedule.module.css";
 
 function ScheduleForm() {
@@ -51,45 +50,43 @@ function ScheduleForm() {
   }
 
   return(
-    <Common>
-      <div className={ Schedule.schedule }>
-        <form className={ Schedule.schedule__form }
-              onSubmit={ handleSubmit }
-        >
-          <label className={ Schedule.schedule__label }>
-            日付：
-            <input  type="date"
-                    name="date"
-                    placeholder="日付の選択をしてください"
-                    className={ Schedule.schedule__content }
+    <div className={ Schedule.schedule }>
+      <form className={ Schedule.schedule__form }
+          onSubmit={ handleSubmit }
+      >
+        <label className={ Schedule.schedule__label }>
+          日付：
+          <input  type="date"
+                  name="date"
+                  placeholder="日付の選択をしてください"
+                  className={ Schedule.schedule__content }
+                  onChange={ handleChange }
+          />
+        </label>
+        <label className={ Schedule.schedule__label }>
+          要件：
+          <input  type="text"
+                  name="requirement"
+                  placeholder="内容を入力してください"
+                  className={ Schedule.schedule__content }
+                  onChange={ handleChange }
+          />
+        </label>
+        <label className={ Schedule.schedule__label }>
+          メモ：
+          <textarea className={ Schedule.schedule__content }
+                    name="memo"
                     onChange={ handleChange }
-            />
-          </label>
-          <label className={ Schedule.schedule__label }>
-            要件：
-            <input  type="text"
-                    name="requirement"
-                    placeholder="内容を入力してください"
-                    className={ Schedule.schedule__content }
-                    onChange={ handleChange }
-            />
-          </label>
-          <label className={ Schedule.schedule__label }>
-            メモ：
-            <textarea className={ Schedule.schedule__content }
-                      name="memo"
-                      onChange={ handleChange }
-            >
-            </textarea>
-          </label>
-          <div>
-            <input  type="submit"
-                    value="作成"
-            />
-          </div>
-        </form>
-      </div>
-    </Common>
+          >
+          </textarea>
+        </label>
+        <div>
+          <input  type="submit"
+                  value="作成"
+          />
+        </div>
+      </form>
+    </div>
   )
 }
 

--- a/src/clnd/resources/js/css/calender.module.css
+++ b/src/clnd/resources/js/css/calender.module.css
@@ -23,3 +23,18 @@
 .calender__inner {
   padding: 64px 0;
 }
+
+.calender__btn {
+  position: fixed;
+  bottom: 12px;
+  right: 12px;
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-size: 64px;
+  background: dodgerblue;
+  color: white;
+}

--- a/src/clnd/resources/js/css/schedule.module.css
+++ b/src/clnd/resources/js/css/schedule.module.css
@@ -1,12 +1,17 @@
 .schedule {
   font-size: 12px;
   padding: 16px;
-  background: white;
+  background: aliceblue;
   width: 320px;
   display: flex;
   justify-content: center;
   text-align: center;
   margin: 0 auto;
+  position: fixed;
+  top: 80px;
+  right: 50px;
+  left: 50px;
+  box-shadow: 0 0 8px gray;
 }
 .schedule__form {
   display: flex;

--- a/src/clnd/routes/web.php
+++ b/src/clnd/routes/web.php
@@ -12,8 +12,6 @@ Route::inertia('/login', 'Login');
  * task: 認証成功した後のルートを作成する
  */
 Route::inertia('/calender', 'Calender');
-// 仮ルート
-Route::inertia('/schedule', 'Schedule');
 
 /**
  * 管理者側


### PR DESCRIPTION
### Why

カレンダーページに予定を投稿するためのフォームを設置する。

### What

予定登録フォームの呼び出しをするボタンを設置。
デザインを調整し、カレンダー上に浮かしてフォームを表示させる。

https://github.com/yuuki-kurose/clnd-main/assets/103484621/fcdba27e-7a5b-44cd-a663-4faf2582997f


close #23 