### PR TITLE
Dev: カレンダーページに、予定登録内容を反映させる

### DIFF
--- a/src/clnd/resources/js/Pages/Calender.jsx
+++ b/src/clnd/resources/js/Pages/Calender.jsx
@@ -1,26 +1,37 @@
-import React, { useState }  from 'react';
+import React, { useState, useEffect } from 'react';
 import Calender from '../scss/calender.module.scss';
 import ScheduleForm from '../Pages/Schedule';
 import HeaderCommon from '../Layout/header';
 
-function calenderUserPage() {
+const CalenderUserPage = function(props) {
+  /**
+   * カレンダーページ表示
+   */
   // 現在の年月を取得
   const [year, setYear] = useState(new Date().getFullYear());
   const [month, setMonth] = useState(new Date().getMonth()+1);
+  // カレンダーの日付を反映する関数を呼び出し
+  const calender = createCalender(year, month);
+  // 当月の最後日を取得
+  const last = new Date(year, month, 0).getDate();
+  // 前月の最後日を取得
+  const prevlast = new Date(year,month-1, 0).getDate();
 
+  /**
+   * カレンダーページに予定を登録
+   */
+  const { responseData } = props;
+  const [viewData, setViewData] = useState(responseData);
+  useEffect(() => {
+    setViewData(responseData);
+  })
+  
+
+  /**
+   * カレンダーページ上のアクションボタン
+   */
   // 予定作成フォームの状態を取得
   const [openForm, setOpenForm] = useState(false);
-
-  // カレンダーに反映する関数
-  const calender = createCalender(year, month);
-
-  // 当月の最後日
-  const last = new Date(year, month, 0).getDate();
-  console.log(last);
-  // 前月の最後日
-  const prevlast = new Date(year,month-1, 0).getDate();
-  console.log(prevlast);
-
   // 予定作成フォームの表示/非表示
   const handleClick = () => {
     setOpenForm(!openForm);
@@ -49,6 +60,7 @@ function calenderUserPage() {
               </tr>
             </thead>
             <tbody>
+              {/* task: コードの分解と理解 */}
               { calender.map((week,i) => (
                 <tr key={ week.join('') }>
                   { week.map((day,j) => (
@@ -58,6 +70,13 @@ function calenderUserPage() {
                           {day > last ? day - last : day <= 0 ? prevlast + day : day }
                         </div>
                         <div> 
+                          {/* 各日に対し予定登録があった場合、データをセットする */}
+                          { viewData &&
+                            <div>
+                              <p>レスポンスデータが渡ってきました</p>
+                              <pre>{ JSON.stringify(responseData, null, 2) }</pre>
+                            </div>
+                          }
                         </div>
                       </div>
                     </td>
@@ -79,17 +98,33 @@ function calenderUserPage() {
       </div>
     </div>
   )
-}
+};
 
+/**
+ * カレンダー表示に使用する関数
+ */
 function createCalender(year, month) {
-  const firstDay = new Date(year, month -1, 1).getDay();
-  console.log(firstDay);
-  return [0,1,2,3,4].map((weekIndex) => {
-    return [0,1,2,3,4,5,6].map((dayIndex) => {
-        const day = dayIndex + 1 + weekIndex * 7
-        return day - firstDay
-    })
-  })
-}
+  // 5週分の行を用意
+  const weekArray = [0,1,2,3,4];
+  // 7日分の列を用意
+  const dayArray = [0,1,2,3,4,5,6];
+  // 今月１日の曜日を取得する
+  const firstDay = new Date(year, month-1, 1).getDay();
+  // console.log(firstDay);
 
-export default calenderUserPage;
+  // 1週に７日分を埋め込む
+  return weekArray.map((weekNum) => {
+    return dayArray.map((dayNum) => {
+      // 日付を正しい表記にする
+      const day = dayNum + 1;
+      // 週ごとに７日ずつ増えるので７をかける
+      const week = weekNum * 7;
+      // 1週ごとの日付を計算し、取得する
+      const estimation = day + week;
+      // 最初の曜日から引くことで、前月の日にちの曜日を取得する
+      return estimation - firstDay;
+    });
+  });
+};
+
+export default CalenderUserPage;

--- a/src/clnd/resources/js/Pages/Calender.jsx
+++ b/src/clnd/resources/js/Pages/Calender.jsx
@@ -1,12 +1,9 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import Calender from '../scss/calender.module.scss';
 import ScheduleForm from '../Pages/Schedule';
 
-const CalenderUserPage = function(props) {
-  /**
-   * カレンダーページ表示
-   */
-  // 現在の年月を取得
+const CalenderUserPage = React.memo(function({ updateEvents }) {
+
   const [year, setYear] = useState(new Date().getFullYear());
   const [month, setMonth] = useState(new Date().getMonth()+1);
   // カレンダーの日付を反映する関数を呼び出し
@@ -16,18 +13,6 @@ const CalenderUserPage = function(props) {
   // 前月の最後日を取得
   const prevlast = new Date(year,month-1, 0).getDate();
 
-  /**
-   * カレンダーページに予定を登録
-   */
-  const { responseData } = props;
-  const [viewData, setViewData] = useState(responseData);
-  useEffect(() => {
-    setViewData(responseData);
-  }, [responseData]);
-
-  /**
-   * カレンダーページ上のアクションボタン
-   */
   // 予定作成フォームの状態を取得
   const [openForm, setOpenForm] = useState(false);
   // 予定作成フォームの表示/非表示
@@ -35,7 +20,7 @@ const CalenderUserPage = function(props) {
     setOpenForm(!openForm);
   };
 
-  return(
+  return (
     <div>
       {/* カレンダーページ */}
       <div className={ Calender.calender }>
@@ -66,12 +51,6 @@ const CalenderUserPage = function(props) {
                           {day > last ? day - last : day <= 0 ? prevlast + day : day }
                         </div>
                         <div>
-                        { viewData && (
-                          <div>
-                          <p>レスポンス結果が渡ってきました</p>
-                          <pre>{ JSON.stringify(responseData, null, 2) }</pre>
-                          </div>
-                        )}
                         </div>
                       </div>
                     </td>
@@ -80,7 +59,6 @@ const CalenderUserPage = function(props) {
               ))}
             </tbody>
           </table>
-
           {/* 予定作成フォームコンポーネントの呼び出し */}
           <div>
             <button className={ Calender.calender__btn }
@@ -92,8 +70,8 @@ const CalenderUserPage = function(props) {
         </div>
       </div>
     </div>
-  )
-};
+  );
+});
 
 /**
  * カレンダー表示に使用する関数

--- a/src/clnd/resources/js/Pages/Calender.jsx
+++ b/src/clnd/resources/js/Pages/Calender.jsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import Calender from '../scss/calender.module.scss';
 import ScheduleForm from '../Pages/Schedule';
-import HeaderCommon from '../Layout/header';
 
 const CalenderUserPage = function(props) {
   /**
@@ -20,11 +19,11 @@ const CalenderUserPage = function(props) {
   /**
    * カレンダーページに予定を登録
    */
-
-  const [responseData, setResponseData] = useState(null);
+  const { responseData } = props;
+  const [viewData, setViewData] = useState(responseData);
   useEffect(() => {
-    setResponseData(props.responseData);
-  }, [props.responseData]);
+    setViewData(responseData);
+  }, [responseData]);
 
   /**
    * カレンダーページ上のアクションボタン
@@ -38,8 +37,6 @@ const CalenderUserPage = function(props) {
 
   return(
     <div>
-      <HeaderCommon />
-
       {/* カレンダーページ */}
       <div className={ Calender.calender }>
         <div className={ Calender.calender__header }>
@@ -68,14 +65,13 @@ const CalenderUserPage = function(props) {
                         <div className={ Calender.calender__inner }>
                           {day > last ? day - last : day <= 0 ? prevlast + day : day }
                         </div>
-                        <div> 
-                          {/* 各日に対し予定登録があった場合、データをセットする */}
-                          { responseData && (
-                            <div>
-                              <p>レスポンスデータが渡ってきました</p>
-                              <pre>{ JSON.stringify(responseData, null, 2) }</pre>
-                            </div>
-                          )}
+                        <div>
+                        { viewData && (
+                          <div>
+                          <p>レスポンス結果が渡ってきました</p>
+                          <pre>{ JSON.stringify(responseData, null, 2) }</pre>
+                          </div>
+                        )}
                         </div>
                       </div>
                     </td>

--- a/src/clnd/resources/js/Pages/Calender.jsx
+++ b/src/clnd/resources/js/Pages/Calender.jsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import Calender from '../scss/calender.module.scss';
 import ScheduleForm from '../Pages/Schedule';
 
-const CalenderUserPage = React.memo(function({ updateEvents }) {
+const CalenderUserPage = React.memo(function() {
 
   const [year, setYear] = useState(new Date().getFullYear());
   const [month, setMonth] = useState(new Date().getMonth()+1);
@@ -18,6 +18,16 @@ const CalenderUserPage = React.memo(function({ updateEvents }) {
   // 予定作成フォームの表示/非表示
   const handleClick = () => {
     setOpenForm(!openForm);
+  };
+
+  // Schedule.jsxから値が返ってくるので取得し、更新する
+  const [responseViewData, setResponseViewData] = useState({
+    date: '',
+    requirement: '',
+    memo: '',
+  });
+  const passToResponseData = (data) => {
+    setResponseViewData(data);
   };
 
   return (
@@ -50,7 +60,11 @@ const CalenderUserPage = React.memo(function({ updateEvents }) {
                         <div className={ Calender.calender__inner }>
                           {day > last ? day - last : day <= 0 ? prevlast + day : day }
                         </div>
-                        <div>
+                        {/* 取得したデータを反映させる */}
+                        <div className={ Calender.calender__content }>
+                          { responseViewData && (
+                            <p className={ Calender.calender__detail }>{ responseViewData.requirement }</p>
+                          )}
                         </div>
                       </div>
                     </td>
@@ -65,7 +79,7 @@ const CalenderUserPage = React.memo(function({ updateEvents }) {
                     onClick={ handleClick }
             >+
             </button>
-            { openForm && <ScheduleForm />}
+            { openForm && <ScheduleForm passToResponseData={ passToResponseData } />}
           </div>
         </div>
       </div>

--- a/src/clnd/resources/js/Pages/Calender.jsx
+++ b/src/clnd/resources/js/Pages/Calender.jsx
@@ -20,12 +20,11 @@ const CalenderUserPage = function(props) {
   /**
    * カレンダーページに予定を登録
    */
-  const { responseData } = props;
-  const [viewData, setViewData] = useState(responseData);
+
+  const [responseData, setResponseData] = useState(null);
   useEffect(() => {
-    setViewData(responseData);
-  })
-  
+    setResponseData(props.responseData);
+  }, [props.responseData]);
 
   /**
    * カレンダーページ上のアクションボタン
@@ -71,12 +70,12 @@ const CalenderUserPage = function(props) {
                         </div>
                         <div> 
                           {/* 各日に対し予定登録があった場合、データをセットする */}
-                          { viewData &&
+                          { responseData && (
                             <div>
                               <p>レスポンスデータが渡ってきました</p>
                               <pre>{ JSON.stringify(responseData, null, 2) }</pre>
                             </div>
-                          }
+                          )}
                         </div>
                       </div>
                     </td>

--- a/src/clnd/resources/js/Pages/Feature.jsx
+++ b/src/clnd/resources/js/Pages/Feature.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from "react";
 
-const FeatureOfForm = ({ handleAddEvent, scheduleFormData }) => {
+const FeatureOfForm = ({ formData, handleAddEvent, submitEvent }) => {
   // レスポンスデータを格納する変数定義
   const [updateEvents, setUpdateEvents] = useState('');
  
@@ -19,7 +19,7 @@ const FeatureOfForm = ({ handleAddEvent, scheduleFormData }) => {
           'CONTENT-TYPE': 'application/json',
           'X-CSRF-TOKEN': csrfToken,
         },
-        body: JSON.stringify(scheduleFormData)
+        body: JSON.stringify(formData)
       });
       if(!response.ok) {
         throw new Error('エラーが出ました');
@@ -34,10 +34,10 @@ const FeatureOfForm = ({ handleAddEvent, scheduleFormData }) => {
     }
   };
 
-  // コンポーネントがマウントする時だけバックエンドとのやり取りを行う
+  // Schedule.jsxで送信イベントが行われた場合のみ、バックエンドとのやり取りを行う
   useEffect(() => {
-    handleSubmit();
-  }, [scheduleFormData]);
+   handleSubmit(formData);
+  }, [submitEvent]);
 };
 
 export default FeatureOfForm;

--- a/src/clnd/resources/js/Pages/Feature.jsx
+++ b/src/clnd/resources/js/Pages/Feature.jsx
@@ -1,0 +1,43 @@
+import React, { useState, useEffect } from "react";
+
+const FeatureOfForm = ({ handleAddEvent, scheduleFormData }) => {
+  // レスポンスデータを格納する変数定義
+  const [updateEvents, setUpdateEvents] = useState('');
+ 
+  // csrfトークン取得
+  const csrfToken = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
+
+  // APIルート
+  const scheduleApiUrl = '/api/schedule';
+
+  // フォームデータの送信・レスポンスの取得
+  const handleSubmit = async() => {
+    try {
+      const response = await fetch(scheduleApiUrl, {
+        method: 'POST',
+        headers: {
+          'CONTENT-TYPE': 'application/json',
+          'X-CSRF-TOKEN': csrfToken,
+        },
+        body: JSON.stringify(scheduleFormData)
+      });
+      if(!response.ok) {
+        throw new Error('エラーが出ました');
+      }
+      const data = await response.json();
+      setUpdateEvents(data);
+
+      // 子（Schedule.jsx）コンポーネントの関数を使用する
+      handleAddEvent(data);
+    } catch(error) {
+      console.log(error);
+    }
+  };
+
+  // コンポーネントがマウントする時だけバックエンドとのやり取りを行う
+  useEffect(() => {
+    handleSubmit();
+  }, [scheduleFormData]);
+};
+
+export default FeatureOfForm;

--- a/src/clnd/resources/js/Pages/Schedule.jsx
+++ b/src/clnd/resources/js/Pages/Schedule.jsx
@@ -15,7 +15,7 @@ function ScheduleForm() {
   const [responseData, setResponseData] = useState(null);
 
   // フォームの表示・非表示の変数定義
-  const [formSubmitted, setFormSubmitted] = useState(false);
+  const [formSubmitted, setFormSubmitted] = useState(true);
 
   // 入力内容の反映
   const handleChange = (event) => {
@@ -29,11 +29,7 @@ function ScheduleForm() {
   // フォームデータ送信
   const handleSubmit = (event) => {
     event.preventDefault();
-
-    // API定義
     const scheduleApiUrl = '/api/schedule';
-
-    // 送信形態
     const requestOptions = {
       method: 'POST',
       headers: {
@@ -42,63 +38,62 @@ function ScheduleForm() {
       },
       body: JSON.stringify(scheduleForm)
     };
-
-    // リクエストを送信、レスポンスを受け取る
     fetch(scheduleApiUrl, requestOptions)
       .then(response => response.json())
       .then(data => {
         setResponseData(data);
-        setFormSubmitted(true);
+        setFormSubmitted(false);
       })
       .catch((error) => {
         console.log(error);
     });
-  }
+  };
 
   return(
-    <div className={`${ Schedule.schedule } ${ formSubmitted ? Schedule.hidden: ''}`}>
-      <form className={ Schedule.schedule__form }
-          onSubmit={ handleSubmit }
-      >
-        <label className={ Schedule.schedule__label }>
-          日付：
-          <input  type="date"
-                  name="date"
-                  placeholder="日付の選択をしてください"
-                  className={ Schedule.schedule__content }
-                  onChange={ handleChange }
-          />
-        </label>
-        <label className={ Schedule.schedule__label }>
-          要件：
-          <input  type="text"
-                  name="requirement"
-                  placeholder="内容を入力してください"
-                  className={ Schedule.schedule__content }
-                  onChange={ handleChange }
-          />
-        </label>
-        <label className={ Schedule.schedule__label }>
-          メモ：
-          <textarea className={ Schedule.schedule__content }
-                    name="memo"
-                    onChange={ handleChange }
+    <div>
+      { formSubmitted && (
+        <div className={ Schedule.schedule }>
+          <form className={ Schedule.schedule__form }
+                onSubmit={ handleSubmit }
           >
-          </textarea>
-        </label>
-        <div>
-          <input  type="submit"
-                  value="作成"
-          />
+            <label className={ Schedule.schedule__label }>
+              日付：
+              <input  type="date"
+                      name="date"
+                      placeholder="日付の選択をしてください"
+                      className={ Schedule.schedule__content }
+                      onChange={ handleChange }
+              />
+            </label>
+            <label className={ Schedule.schedule__label }>
+              要件：
+              <input  type="text"
+                      name="requirement"
+                      placeholder="内容を入力してください"
+                      className={ Schedule.schedule__content }
+                      onChange={ handleChange }
+              />
+            </label>
+            <label className={ Schedule.schedule__label }>
+              メモ：
+              <textarea className={ Schedule.schedule__content }
+                        name="memo"
+                        onChange={ handleChange }
+              >
+              </textarea>
+            </label>
+            <div>
+              <input  type="submit"
+                      value="作成"
+              />
+            </div>
+          </form>
         </div>
-      </form>
-      {/* { formSubmitted && (
-        alert('フォームが送信されました')
-      )} */}
+      )}
       {/* カレンダーコンポーネントにレスポンスデータのみを渡す */}
       { responseData && <CalenderUserPage responseData={ responseData } />}
     </div>
-  )
-}
+  );
+};
 
 export default ScheduleForm;

--- a/src/clnd/resources/js/Pages/Schedule.jsx
+++ b/src/clnd/resources/js/Pages/Schedule.jsx
@@ -1,52 +1,36 @@
-import { useState } from "react";
+import React, { useState } from 'react';
 import Schedule from "../scss/schedule.module.scss";
-import CalenderUserPage from "./Calender";
+import FeatureOfForm from './Feature';
 
-function ScheduleForm() {
-
+const ScheduleForm = ({ passToResponseData }) => {
   // フォームデータ変数定義
-  const [scheduleForm, setScheduleForm] = useState({
+  const [scheduleFormData, setScheduleFormData] = useState({
     date: '',
     requirement: '',
     memo: '',
   });
 
-  // レスポンスデータ変数定義
-  const [responseData, setResponseData] = useState(null);
+   // フォームの表示・非表示の変数定義
+   const [formSubmitted, setFormSubmitted] = useState(true);
 
-  // フォームの表示・非表示の変数定義
-  const [formSubmitted, setFormSubmitted] = useState(true);
-
-  // 入力内容の反映
+   // 入力内容の反映
   const handleChange = (event) => {
     const { name, value } = event.target;
-    setScheduleForm({ ...scheduleForm, [name]: value});
-  }
+    setScheduleFormData({ ...scheduleFormData, [name]: value});
+    console.log(scheduleFormData);
+  };
 
-  // csrfトークン取得
-  const csrfToken = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
-
-  // フォームデータ送信
-  const handleSubmit = (event) => {
+  // props経由で関数を使用し、Feature.jsxに値を渡す
+  const handleInputSubmit = (event) => {
     event.preventDefault();
-    const scheduleApiUrl = '/api/schedule';
-    const requestOptions = {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'X-CSRF-TOKEN': csrfToken,
-      },
-      body: JSON.stringify(scheduleForm)
-    };
-    fetch(scheduleApiUrl, requestOptions)
-      .then(response => response.json())
-      .then(data => {
-        setResponseData(data);
-        setFormSubmitted(false);
-      })
-      .catch((error) => {
-        console.log(error);
-    });
+    setScheduleFormData(scheduleFormData);
+    setFormSubmitted(false);
+  };
+
+  // レスポンスデータをセットし、親（Calender .jsx)の関数を呼び出す
+  // task: カレンダーコンポーネント内にpassToResponseDataの定義を行う
+  const handleAddEvent = (data) => {
+    passToResponseData(data);
   };
 
   return(
@@ -54,7 +38,7 @@ function ScheduleForm() {
       { formSubmitted && (
         <div className={ Schedule.schedule }>
           <form className={ Schedule.schedule__form }
-                onSubmit={ handleSubmit }
+                onSubmit={ handleInputSubmit }
           >
             <label className={ Schedule.schedule__label }>
               日付：
@@ -87,11 +71,11 @@ function ScheduleForm() {
                       value="作成"
               />
             </div>
+            {/* 機能コンポーネントにフォームデータを渡す */}
+            <FeatureOfForm scheduleFormData={ scheduleFormData } handleAddEvent={ handleAddEvent } />
           </form>
         </div>
       )}
-      {/* カレンダーコンポーネントにレスポンスデータのみを渡す */}
-      { responseData && <CalenderUserPage responseData={ responseData } />}
     </div>
   );
 };

--- a/src/clnd/resources/js/Pages/Schedule.jsx
+++ b/src/clnd/resources/js/Pages/Schedule.jsx
@@ -14,11 +14,13 @@ function ScheduleForm() {
   // レスポンスデータ変数定義
   const [responseData, setResponseData] = useState(null);
 
+  // フォームの表示・非表示の変数定義
+  const [formSubmitted, setFormSubmitted] = useState(false);
+
   // 入力内容の反映
   const handleChange = (event) => {
     const { name, value } = event.target;
     setScheduleForm({ ...scheduleForm, [name]: value});
-    console.log(scheduleForm);
   }
 
   // csrfトークン取得
@@ -46,6 +48,7 @@ function ScheduleForm() {
       .then(response => response.json())
       .then(data => {
         setResponseData(data);
+        setFormSubmitted(true);
       })
       .catch((error) => {
         console.log(error);
@@ -53,7 +56,7 @@ function ScheduleForm() {
   }
 
   return(
-    <div className={ Schedule.schedule }>
+    <div className={`${ Schedule.schedule } ${ formSubmitted ? Schedule.hidden: ''}`}>
       <form className={ Schedule.schedule__form }
           onSubmit={ handleSubmit }
       >
@@ -89,8 +92,11 @@ function ScheduleForm() {
           />
         </div>
       </form>
+      {/* { formSubmitted && (
+        alert('フォームが送信されました')
+      )} */}
       {/* カレンダーコンポーネントにレスポンスデータのみを渡す */}
-      { responseData && <CalenderUserPage responseData={ responseData } /> }
+      { responseData && <CalenderUserPage responseData={ responseData } />}
     </div>
   )
 }

--- a/src/clnd/resources/js/Pages/Schedule.jsx
+++ b/src/clnd/resources/js/Pages/Schedule.jsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import Schedule from "../scss/schedule.module.scss";
+import CalenderUserPage from "./Calender";
 
 function ScheduleForm() {
 
@@ -9,6 +10,9 @@ function ScheduleForm() {
     requirement: '',
     memo: '',
   });
+
+  // レスポンスデータ変数定義
+  const [responseData, setResponseData] = useState(null);
 
   // 入力内容の反映
   const handleChange = (event) => {
@@ -37,16 +41,15 @@ function ScheduleForm() {
       body: JSON.stringify(scheduleForm)
     };
 
+    // リクエストを送信、レスポンスを受け取る
     fetch(scheduleApiUrl, requestOptions)
       .then(response => response.json())
       .then(data => {
-        if(data.message) {
-          console.log(data.message);
-        }
+        setResponseData(data);
       })
-      .catch(error => {
+      .catch((error) => {
         console.log(error);
-      })
+    });
   }
 
   return(
@@ -86,6 +89,8 @@ function ScheduleForm() {
           />
         </div>
       </form>
+      {/* カレンダーコンポーネントにレスポンスデータのみを渡す */}
+      { responseData && <CalenderUserPage responseData={ responseData } /> }
     </div>
   )
 }

--- a/src/clnd/resources/js/Pages/Schedule.jsx
+++ b/src/clnd/resources/js/Pages/Schedule.jsx
@@ -10,72 +10,68 @@ const ScheduleForm = ({ passToResponseData }) => {
     memo: '',
   });
 
-   // フォームの表示・非表示の変数定義
-   const [formSubmitted, setFormSubmitted] = useState(true);
+  // フォーム送信イベントの制御
+  const [submitEvent, setSubmitEvent] = useState(false);
 
-   // 入力内容の反映
+  // 入力内容の反映
   const handleChange = (event) => {
     const { name, value } = event.target;
     setScheduleFormData({ ...scheduleFormData, [name]: value});
-    console.log(scheduleFormData);
   };
 
   // props経由で関数を使用し、Feature.jsxに値を渡す
-  const handleInputSubmit = (event) => {
+  const handleInputSubmit = async(event) => {
     event.preventDefault();
-    setScheduleFormData(scheduleFormData);
-    setFormSubmitted(false);
+    handleAddEvent(scheduleFormData);
+    setSubmitEvent(true);
   };
 
   // レスポンスデータをセットし、親（Calender .jsx)の関数を呼び出す
-  // task: カレンダーコンポーネント内にpassToResponseDataの定義を行う
-  const handleAddEvent = (data) => {
-    passToResponseData(data);
+  const handleAddEvent = async(data) => {
+    await passToResponseData(data);
   };
 
   return(
     <div>
-      { formSubmitted && (
-        <div className={ Schedule.schedule }>
-          <form className={ Schedule.schedule__form }
-                onSubmit={ handleInputSubmit }
-          >
-            <label className={ Schedule.schedule__label }>
-              日付：
-              <input  type="date"
-                      name="date"
-                      placeholder="日付の選択をしてください"
-                      className={ Schedule.schedule__content }
+      <div className={ Schedule.schedule }>
+        <form className={ Schedule.schedule__form }
+              onSubmit={ handleInputSubmit }
+        >
+          <label className={ Schedule.schedule__label }>
+            日付：
+            <input  type="date"
+                    name="date"
+                    placeholder="日付の選択をしてください"
+                    className={ Schedule.schedule__content }
+                    onChange={ handleChange }
+            />
+          </label>
+          <label className={ Schedule.schedule__label }>
+            要件：
+            <input  type="text"
+                    name="requirement"
+                    placeholder="内容を入力してください"
+                    className={ Schedule.schedule__content }
+                    onChange={ handleChange }
+            />
+          </label>
+          <label className={ Schedule.schedule__label }>
+            メモ：
+            <textarea className={ Schedule.schedule__content }
+                      name="memo"
                       onChange={ handleChange }
-              />
-            </label>
-            <label className={ Schedule.schedule__label }>
-              要件：
-              <input  type="text"
-                      name="requirement"
-                      placeholder="内容を入力してください"
-                      className={ Schedule.schedule__content }
-                      onChange={ handleChange }
-              />
-            </label>
-            <label className={ Schedule.schedule__label }>
-              メモ：
-              <textarea className={ Schedule.schedule__content }
-                        name="memo"
-                        onChange={ handleChange }
-              >
-              </textarea>
-            </label>
-            <div>
-              <input  type="submit"
-                      value="作成"
-              />
-            </div>
-            {/* 機能コンポーネントにフォームデータを渡す */}
-            <FeatureOfForm scheduleFormData={ scheduleFormData } handleAddEvent={ handleAddEvent } />
-          </form>
-        </div>
-      )}
+            >
+            </textarea>
+          </label>
+          <div>
+            <input  type="submit"
+                    value="作成"
+            />
+          </div>
+          {/* 機能コンポーネントにフォームデータをまとめて渡す */}
+          <FeatureOfForm formData={ scheduleFormData } handleAddEvent={ handleAddEvent } submitEvent={ submitEvent } />
+        </form>
+      </div>
     </div>
   );
 };

--- a/src/clnd/resources/js/scss/calender.module.scss
+++ b/src/clnd/resources/js/scss/calender.module.scss
@@ -1,3 +1,4 @@
+// task: scssの書き方に変更する
 .calender {
   display: flex;
   justify-content: center;
@@ -22,6 +23,16 @@
 
 .calender__inner {
   padding: 64px 0;
+}
+
+.calender__content {
+  background: aliceblue;
+  border-radius: 25px;
+  margin: 0 4px;
+
+  .calender__detail {
+    padding: 4px;
+  }
 }
 
 .calender__btn {

--- a/src/clnd/resources/js/scss/schedule.module.scss
+++ b/src/clnd/resources/js/scss/schedule.module.scss
@@ -26,3 +26,6 @@
   padding: 8px;
   margin: 16px;
 }
+.hidden {
+  display: none;
+}

--- a/src/clnd/resources/js/scss/schedule.module.scss
+++ b/src/clnd/resources/js/scss/schedule.module.scss
@@ -26,6 +26,3 @@
   padding: 8px;
   margin: 16px;
 }
-.hidden {
-  display: none;
-}


### PR DESCRIPTION
### Why

カレンダーページ上に、laravelからのレスポンスデータを受け取り反映させる。

### What

カレンダービューに使用する関数の書き換え。（コピペなので、分解し理解するため）
カレンダービューコンポーネント、フォームコンポーネント、子コンポーネントにそれぞれ分け、親→子→孫内でデータの受け渡しをできるようにする。
（※反映はできたが、日付の結びつけやデータ反映の見直しが必要な箇所は別ブランチで対応）


https://github.com/yuuki-kurose/clnd-main/assets/103484621/01ea67ed-cbd3-42e7-91d3-d5a0089f034c


close #27 