### PR TITLE
Feat: 送信イベントの記述修正、データ反映の挙動見直し

### DIFF
--- a/src/clnd/resources/js/Pages/Calender.jsx
+++ b/src/clnd/resources/js/Pages/Calender.jsx
@@ -20,16 +20,11 @@ const CalenderUserPage = React.memo(function() {
     setOpenForm(!openForm);
   };
 
-  // Schedule.jsxから値が返ってくるので取得し、更新する
-  const [responseViewData, setResponseViewData] = useState({
-    date: '',
-    requirement: '',
-    memo: '',
-  });
-  // task: 再レンダリングの監視をし、responseViewDataに値が反映されるように修正する
+  // Schedule.jsxから値が返ってくるので取得・更新し、フォームを閉じる
+  const [responseViewData, setResponseViewData] = useState(null);
   const passToResponseData = async(data) => {
     setResponseViewData(data);
-    console.log(responseViewData);
+    setOpenForm(!openForm);
   };
 
   return (
@@ -65,7 +60,7 @@ const CalenderUserPage = React.memo(function() {
                         {/* 取得したデータを反映させる */}
                         <div className={ Calender.calender__content }>
                           { responseViewData && (
-                            <p className={ Calender.calender__detail }>{ responseViewData.memo }</p>
+                            <p className={ Calender.calender__detail }>{ responseViewData.validate.requirement }</p>
                           )}
                         </div>
                       </div>

--- a/src/clnd/resources/js/Pages/Calender.jsx
+++ b/src/clnd/resources/js/Pages/Calender.jsx
@@ -26,8 +26,10 @@ const CalenderUserPage = React.memo(function() {
     requirement: '',
     memo: '',
   });
-  const passToResponseData = (data) => {
+  // task: 再レンダリングの監視をし、responseViewDataに値が反映されるように修正する
+  const passToResponseData = async(data) => {
     setResponseViewData(data);
+    console.log(responseViewData);
   };
 
   return (
@@ -63,7 +65,7 @@ const CalenderUserPage = React.memo(function() {
                         {/* 取得したデータを反映させる */}
                         <div className={ Calender.calender__content }>
                           { responseViewData && (
-                            <p className={ Calender.calender__detail }>{ responseViewData.requirement }</p>
+                            <p className={ Calender.calender__detail }>{ responseViewData.memo }</p>
                           )}
                         </div>
                       </div>

--- a/src/clnd/resources/js/Pages/Feature.jsx
+++ b/src/clnd/resources/js/Pages/Feature.jsx
@@ -1,43 +1,23 @@
-import React, { useState, useEffect } from "react";
+// APIルート
+const scheduleApiUrl = '/api/schedule';
 
-const FeatureOfForm = ({ formData, handleAddEvent, submitEvent }) => {
-  // レスポンスデータを格納する変数定義
-  const [updateEvents, setUpdateEvents] = useState('');
- 
-  // csrfトークン取得
-  const csrfToken = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
-
-  // APIルート
-  const scheduleApiUrl = '/api/schedule';
-
-  // フォームデータの送信・レスポンスの取得
-  const handleSubmit = async() => {
-    try {
-      const response = await fetch(scheduleApiUrl, {
-        method: 'POST',
-        headers: {
-          'CONTENT-TYPE': 'application/json',
-          'X-CSRF-TOKEN': csrfToken,
-        },
-        body: JSON.stringify(formData)
-      });
-      if(!response.ok) {
-        throw new Error('エラーが出ました');
-      }
-      const data = await response.json();
-      setUpdateEvents(data);
-
-      // 子（Schedule.jsx）コンポーネントの関数を使用する
-      handleAddEvent(data);
-    } catch(error) {
+// フォームデータの送信・レスポンスの取得
+export const postFormData = async({ csrfToken, data }) => {
+  try {
+    const response = await fetch(scheduleApiUrl, {
+      method: 'POST',
+      headers: {
+        'CONTENT-TYPE': 'application/json',
+        'X-CSRF-TOKEN': csrfToken,
+      },
+      body: JSON.stringify(data)
+    });
+    if(!response.ok) {
+      throw new Error('エラーが出ました');
+    };
+    return response.json();
+  } catch(error) {
       console.log(error);
-    }
+      return undefined;
   };
-
-  // Schedule.jsxで送信イベントが行われた場合のみ、バックエンドとのやり取りを行う
-  useEffect(() => {
-   handleSubmit(formData);
-  }, [submitEvent]);
 };
-
-export default FeatureOfForm;

--- a/src/clnd/resources/js/Pages/Schedule.jsx
+++ b/src/clnd/resources/js/Pages/Schedule.jsx
@@ -28,7 +28,7 @@ const ScheduleForm = ({ passToResponseData }) => {
     });
     if(response !=null) {
       console.log('渡ってきたデータ：', response);
-      passToResponseData(response);
+      await passToResponseData(response);
     } else {
       console.log('データがありません');
     }

--- a/src/clnd/resources/js/Pages/Schedule.jsx
+++ b/src/clnd/resources/js/Pages/Schedule.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import Schedule from "../scss/schedule.module.scss";
-import FeatureOfForm from './Feature';
+import { postFormData } from './Feature';
 
 const ScheduleForm = ({ passToResponseData }) => {
   // フォームデータ変数定義
@@ -10,25 +10,28 @@ const ScheduleForm = ({ passToResponseData }) => {
     memo: '',
   });
 
-  // フォーム送信イベントの制御
-  const [submitEvent, setSubmitEvent] = useState(false);
-
   // 入力内容の反映
   const handleChange = (event) => {
     const { name, value } = event.target;
     setScheduleFormData({ ...scheduleFormData, [name]: value});
   };
 
-  // props経由で関数を使用し、Feature.jsxに値を渡す
+  // Feature.jsxにあるpostFormData()を呼び出す
   const handleInputSubmit = async(event) => {
     event.preventDefault();
-    handleAddEvent(scheduleFormData);
-    setSubmitEvent(true);
-  };
-
-  // レスポンスデータをセットし、親（Calender .jsx)の関数を呼び出す
-  const handleAddEvent = async(data) => {
-    await passToResponseData(data);
+    // csrfトークン取得
+    const csrfToken = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
+    // responseに、バックエンドからのレスポンスが代入される
+    const response = await postFormData({
+      csrfToken,
+      data: scheduleFormData,
+    });
+    if(response !=null) {
+      console.log('渡ってきたデータ：', response);
+      passToResponseData(response);
+    } else {
+      console.log('データがありません');
+    }
   };
 
   return(
@@ -68,8 +71,6 @@ const ScheduleForm = ({ passToResponseData }) => {
                     value="作成"
             />
           </div>
-          {/* 機能コンポーネントにフォームデータをまとめて渡す */}
-          <FeatureOfForm formData={ scheduleFormData } handleAddEvent={ handleAddEvent } submitEvent={ submitEvent } />
         </form>
       </div>
     </div>


### PR DESCRIPTION
### Why

フォーム送信を行った後、すぐにデータが反映されないので、reactのレンダリングを使用し即座にデータ反映できるように修正する。
useEffectとpropsで呼び出す記述をやめ、分かりやすくデータの流れがわかるように記述を修正する。

### What

フォームコンポーネントと機能コンポーネント間でpropsのやり取りではなく、関数の呼び出しに変更。
カレンダーコンポーネントにデータの反映を行う際に、レンダリングに合わせた処理に修正。


https://github.com/yuuki-kurose/clnd-main/assets/103484621/f29cc6bf-98ee-415f-85ab-0946f6bd974f


close #30 