### PR TITLE
Feat: ログイン処理を非同期処理に変更、ユーザーIDをローカルストレージへ保存

### DIFF
--- a/src/clnd/app/Http/Controllers/LoginController.php
+++ b/src/clnd/app/Http/Controllers/LoginController.php
@@ -8,15 +8,22 @@ use Illuminate\Support\Facades\Auth;
 class LoginController extends Controller {
   public function authenticate(Request $request) {
 
-    $email = $request->input('email');
-    $password = $request->input('password');
+    // リクエストデータの検証
+    $loginUser = $request->validate([
+      'email' => ['required', 'email'],
+      'password' => 'required',
+    ]);
 
-    if(Auth::attempt(['email' => $email, 'password' => $password])) {
+    // 検証後のデータを認証
+    if(Auth::attempt($loginUser)) {
+      // ユーザー情報を取得
+      $user = Auth::user();
       return response()->json([
+        'userId' => $user->id,
         'message' => '認証成功',
         'redirectTo' => '/calender',
       ], 200);
-    } else if(!Auth::attempt(['email' => $email])) {
+    } else if(!Auth::attempt(['email' => $loginUser['email']])) {
       $errors = ['email' => 'メールアドレスが間違っています'];
       return response()->json([
         'message' => '認証失敗',

--- a/src/clnd/package-lock.json
+++ b/src/clnd/package-lock.json
@@ -9,8 +9,7 @@
                 "@react-oauth/google": "^0.12.1",
                 "@vitejs/plugin-react": "^4.1.0",
                 "react": "^18.2.0",
-                "react-dom": "^18.2.0",
-                "react-router-dom": "^6.18.0"
+                "react-dom": "^18.2.0"
             },
             "devDependencies": {
                 "@types/react": "^18.2.38",
@@ -742,14 +741,6 @@
             "peerDependencies": {
                 "react": ">=16.8.0",
                 "react-dom": ">=16.8.0"
-            }
-        },
-        "node_modules/@remix-run/router": {
-            "version": "1.11.0",
-            "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.11.0.tgz",
-            "integrity": "sha512-BHdhcWgeiudl91HvVa2wxqZjSHbheSgIiDvxrF1VjFzBzpTtuDPkOdOi3Iqvc08kXtFkLjhbS+ML9aM8mJS+wQ==",
-            "engines": {
-                "node": ">=14.0.0"
             }
         },
         "node_modules/@types/babel__core": {
@@ -1592,36 +1583,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/react-router": {
-            "version": "6.18.0",
-            "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.18.0.tgz",
-            "integrity": "sha512-vk2y7Dsy8wI02eRRaRmOs9g2o+aE72YCx5q9VasT1N9v+lrdB79tIqrjMfByHiY5+6aYkH2rUa5X839nwWGPDg==",
-            "dependencies": {
-                "@remix-run/router": "1.11.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            },
-            "peerDependencies": {
-                "react": ">=16.8"
-            }
-        },
-        "node_modules/react-router-dom": {
-            "version": "6.18.0",
-            "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.18.0.tgz",
-            "integrity": "sha512-Ubrue4+Ercc/BoDkFQfc6og5zRQ4A8YxSO3Knsne+eRbZ+IepAsK249XBH/XaFuOYOYr3L3r13CXTLvYt5JDjw==",
-            "dependencies": {
-                "@remix-run/router": "1.11.0",
-                "react-router": "6.18.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            },
-            "peerDependencies": {
-                "react": ">=16.8",
-                "react-dom": ">=16.8"
-            }
-        },
         "node_modules/readdirp": {
             "version": "3.6.0",
             "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -2280,11 +2241,6 @@
             "integrity": "sha512-qagsy22t+7UdkYAiT5ZhfM4StXi9PPNvw0zuwNmabrWyMKddczMtBIOARflbaIj+wHiQjnMAsZmzsUYuXeyoSg==",
             "requires": {}
         },
-        "@remix-run/router": {
-            "version": "1.11.0",
-            "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.11.0.tgz",
-            "integrity": "sha512-BHdhcWgeiudl91HvVa2wxqZjSHbheSgIiDvxrF1VjFzBzpTtuDPkOdOi3Iqvc08kXtFkLjhbS+ML9aM8mJS+wQ=="
-        },
         "@types/babel__core": {
             "version": "7.20.3",
             "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.3.tgz",
@@ -2861,23 +2817,6 @@
             "version": "0.14.0",
             "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.0.tgz",
             "integrity": "sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ=="
-        },
-        "react-router": {
-            "version": "6.18.0",
-            "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.18.0.tgz",
-            "integrity": "sha512-vk2y7Dsy8wI02eRRaRmOs9g2o+aE72YCx5q9VasT1N9v+lrdB79tIqrjMfByHiY5+6aYkH2rUa5X839nwWGPDg==",
-            "requires": {
-                "@remix-run/router": "1.11.0"
-            }
-        },
-        "react-router-dom": {
-            "version": "6.18.0",
-            "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.18.0.tgz",
-            "integrity": "sha512-Ubrue4+Ercc/BoDkFQfc6og5zRQ4A8YxSO3Knsne+eRbZ+IepAsK249XBH/XaFuOYOYr3L3r13CXTLvYt5JDjw==",
-            "requires": {
-                "@remix-run/router": "1.11.0",
-                "react-router": "6.18.0"
-            }
         },
         "readdirp": {
             "version": "3.6.0",

--- a/src/clnd/package.json
+++ b/src/clnd/package.json
@@ -20,7 +20,6 @@
         "@react-oauth/google": "^0.12.1",
         "@vitejs/plugin-react": "^4.1.0",
         "react": "^18.2.0",
-        "react-dom": "^18.2.0",
-        "react-router-dom": "^6.18.0"
+        "react-dom": "^18.2.0"
     }
 }

--- a/src/clnd/resources/js/Pages/Calender.tsx
+++ b/src/clnd/resources/js/Pages/Calender.tsx
@@ -6,12 +6,16 @@ import { initialResponseForm } from './Feature';
 
 // Schedule.tsxに渡す関数の型
 type passToResponseDataFunc = (data: extendedResponseData) => Promise<void>;
-
 export interface propsFunc {
   passToResponseData: passToResponseDataFunc;
 };
 
+// CalenderUserPageをmemo化する
 const CalenderUserPage = React.memo(function() {
+
+  // ローカルストレージに保存されているIDの確認
+  const userId = localStorage.getItem('userId');
+  console.log('保存されていたユーザーID：', userId);
 
   const [year, setYear] = useState<number>(new Date().getFullYear());
   const [month, setMonth] = useState<number>(new Date().getMonth()+1);
@@ -40,13 +44,12 @@ const CalenderUserPage = React.memo(function() {
   useEffect(() => {
     if(responseViewData && responseViewData.selectedDate && responseViewData.formFilterData) {
       setFormToFilterData(responseViewData.formFilterData);
-      console.log(formToFilterData);
-    }
-  }, [responseViewData]);
+    };
+  }, [formToFilterData]);
 
+  // カレンダービュー部分
   return (
     <div>
-      {/* カレンダーページ */}
       <div className={ Calender.calender }>
         <div className={ Calender.calender__header }>
           <div>
@@ -74,6 +77,7 @@ const CalenderUserPage = React.memo(function() {
                       if (item.date) {
                       // ユーザー選択日を取得する
                       const itemDate: number = new Date(item.date).getDate();
+                      // console.log(`Item Date: ${itemDate}, Day: ${day}`);
                       return itemDate === day;
                       }
                       return false;
@@ -88,7 +92,7 @@ const CalenderUserPage = React.memo(function() {
                           </div>
                           <div className={Calender.calender__content}>
                             {/* dayDataを使用して、ユーザー選択日に紐付くデータを表示させる */}
-                            {dayData?.map(item => (
+                            {dayData?.map(item => ( 
                               <p key={item.id} className={Calender.calender__detail}>{item.requirement}</p>
                             ))}
                           </div>
@@ -124,17 +128,19 @@ function createCalender(year, month) {
   const dayArray = [0,1,2,3,4,5,6];
   // 今月１日の曜日を取得する
   const firstDay = new Date(year, month-1, 1).getDay();
-  // console.log(firstDay);
 
   // 1週に７日分を埋め込む
   return weekArray.map((weekNum) => {
     return dayArray.map((dayNum) => {
       // 日付を正しい表記にする
       const day = dayNum + 1;
+      // console.log(day);
       // 週ごとに７日ずつ増えるので７をかける
       const week = weekNum * 7;
+      // console.log(week);
       // 1週ごとの日付を計算し、取得する
       const estimation = day + week;
+      // console.log(estimation);
       // 最初の曜日から引くことで、前月の日にちの曜日を取得する
       return estimation - firstDay;
     });

--- a/src/clnd/resources/js/Pages/Feature.tsx
+++ b/src/clnd/resources/js/Pages/Feature.tsx
@@ -1,9 +1,11 @@
 // レスポンスデータ内のformFilterDataの型
 export interface initialResponseForm {
   id: number;
+  date: string;
   requirement: string;
   memo: string;
   created_at: string;
+  updated_at: string;
 };
 
 // レスポンスデータの型

--- a/src/clnd/resources/js/Pages/Login.tsx
+++ b/src/clnd/resources/js/Pages/Login.tsx
@@ -5,7 +5,15 @@ import Common from '../Layout/common';
 import Login from '../scss/login.module.scss';
 import { initialUserContent } from './Register';
 
-function loginUserForm() {
+// ログインレスポンスデータの型
+interface loginUserData {
+  message: string;
+  redirectTo: string;
+  userId: number;
+};
+
+function LoginUserForm() {
+
   // ログインフォーム変数定義
   const [loginForm, setLoginForm] = useState<initialUserContent>({
     name: '',
@@ -23,52 +31,32 @@ function loginUserForm() {
   const handleChange = (event) => {
     const { name, value } = event.target;
     setLoginForm({ ...loginForm, [name]: value });
-  }
-
-  // ログインフォーム送信
-  const handleSubmit = (event) => {
-    event.preventDefault();
-
-    // エンドポイント
-    const apiUrl = '/api/login';
-
-    // 送信形態
-    const requestOptions = {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify(loginForm)
-    }
-
-    // laravelからレスポンスデータ取得
-    fetch(apiUrl, requestOptions)
-      .then(response => response.json())
-      .then(data => {
-        if(data.message === "認証成功") {
-          console.log(data.message);
-          window.location.href = data.redirectTo;
-        } else if(data.message === "認証失敗") {
-          if(data.errors.email) {
-            setErrors({
-              email: data.errors.email,
-              password: '',
-            });
-          } else if(data.errors.password) {
-            /**
-             * task: パスワードのエラーハンドリング見直し
-             */
-            setErrors({
-              email: '',
-              password: data.errors.password,
-            });
-          }
-        }
-      });
   };
 
-  // VITEの環境変数確認
-  // console.log(import.meta.env.VITE_GOOGLE_CLIENT_ID);
+  // エンドポイント
+  const apiUrl = '/api/login';
+
+  // ログインリクエスト・レスポンス取得
+  const handleSubmit = async(event) => {
+    event.preventDefault();
+    try {
+      const response = await fetch(apiUrl, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(loginForm)
+      });
+      const responseLoginData: loginUserData = await response.json();
+      // ユーザーIDをローカルストレージに保存し、カレンダーページへ遷移
+      if(responseLoginData) {
+        localStorage.setItem('userId', responseLoginData.userId.toString());
+        window.location.href = responseLoginData.redirectTo;
+      }
+    } catch(error) {
+      console.log(error);
+    };
+  };
 
   return(
     <Common>
@@ -125,4 +113,4 @@ export function ProsessToProvider() {
   );
 };
 
-export default loginUserForm;
+export default LoginUserForm;

--- a/src/clnd/routes/web.php
+++ b/src/clnd/routes/web.php
@@ -12,11 +12,6 @@ Route::inertia('/register', 'Register');
 Route::inertia('/login', 'Login');
 
 /**
- * task: 認証成功した後のルートを作成する
- */
-Route::inertia('/calender', 'Calender');
-
-/**
  * 管理者側
  */
 Route::inertia('/admin/register', 'admin/Register');


### PR DESCRIPTION
### Why

ログイン処理が非同期になっていなかったので修正し、ページ遷移時にユーザーIDをローカルストレージに保存する。(遷移先のカレンダーページ内で使用するため）

### What

バックエンド側で、ユーザーIDをレスポンスデータ内に含め、フロント側で受け取りローカルストレージ内に保存する。遷移先でコンソールで確認。

![スクリーンショット 2023-11-30 6 16 24](https://github.com/yuuki-kurose/clnd-main/assets/103484621/4dfeae6f-4b02-4012-a0e1-cb15ffe1875c)


close #38 